### PR TITLE
Use relative import in __init__.py

### DIFF
--- a/jsonrpc_ns/__init__.py
+++ b/jsonrpc_ns/__init__.py
@@ -1,1 +1,1 @@
-from jsonrpc import *  # NOQA
+from .jsonrpc import *  # NOQA


### PR DESCRIPTION
Fixes jsonrpcake on Python 3.8

    File "/lib/python3.9/site-packages/jsonrpc_ns/__init__.py", line 1, in <module>
        from jsonrpc import *  # NOQA
    ModuleNotFoundError: No module named 'jsonrpc'

This library can actually be a single file Python module.